### PR TITLE
Correct "bytes_written" telemetry

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -137,8 +137,9 @@ where
                 };
                 if let Ok(filled_bytes) = res {
                     self.fp.write(&slice[0..filled_bytes]).await?;
+                    counter!("bytes_written", filled_bytes as u64, &labels);
+
                     bytes_written += filled_bytes as u64;
-                    counter!("bytes_written", bytes_written, &labels);
                     gauge!("current_target_size_bytes", bytes_written as f64, &labels);
                 } else {
                     counter!("unable_to_write_to_target", 1, &labels);


### PR DESCRIPTION
Internal to file_gen's LogTarget is the notion of bytes_written, which is what
tracks progress toward the maximum file size of the target. Also there is a
bytes_written that is output as telemetry which really tracks the bytes filled
into the buffer, not the global size. Unfortunately because of name confusion I
got the whole mess confused and it looked like, from telemetry, that byte output
rate was getting faster and faster. Provably not accurate by looking at the
file.

Closes #4

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>