### PR TITLE
Disable cargo-bloat on pull requests

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -1,7 +1,6 @@
 name: Cargo Bloat
 
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
This commit disables cargo-bloat from being run on pull requests as doing so
never quite works for dependabot, for reasons I do not understand. Works fine
otherwise, which is primarily where I want it.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>