### PR TITLE
Use rayon to push faster byte block builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,11 +282,12 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "file_gen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arbitrary",
  "argh",
  "byte-unit",
+ "bytecount",
  "futures",
  "governor",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_gen"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"
@@ -12,6 +12,7 @@ description = "A repeatable file generating program."
 [dependencies]
 toml = "0.5"
 rayon = "1.5"
+bytecount = "0.6"
 
 [dependencies.arbitrary]
 version = "1"
@@ -69,6 +70,6 @@ default-features = false
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util"]
 
 [profile.release]
-lto = true        # Optimize our binary at link stage.
-codegen-units = 1 # Increases compile time but improves optmization alternatives.
-opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
+# lto = true        # Optimize our binary at link stage.
+# codegen-units = 1 # Increases compile time but improves optmization alternatives.
+# opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -21,6 +21,10 @@ impl<'a> Arbitrary<'a> for Member {
             .for_each(|item| *item = CHARSET[(*item % CHARSET_LEN) as usize]);
         Ok(Member { bytes })
     }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (100, Some(6144)) // 100B to 6KiB
+    }
 }
 
 #[derive(Arbitrary, Debug)]


### PR DESCRIPTION
This commit breaks up the block building into iterators so that we can bring
rayon to bear in their construction. This significantly reduces startup time.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>