### PR TITLE
Use less CPU for slow targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "file_gen"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arbitrary",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_gen"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"
@@ -70,6 +70,6 @@ default-features = false
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util"]
 
 [profile.release]
-# lto = true        # Optimize our binary at link stage.
-# codegen-units = 1 # Increases compile time but improves optmization alternatives.
-# opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
+lto = true        # Optimize our binary at link stage.
+codegen-units = 1 # Increases compile time but improves optmization alternatives.
+opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ throughput as possible. In the 0.3 series we have pivoted to a slower line
 construction mechanism but relied on prebuilding blocks to write, dramatically
 improving total throughput up to the limit of 4Gb/s per target duplicate. This
 is currently a hard limit based on a u32 embedded in the program. See "Weird
-Quirks".
+Quirks". To avoid excessive CPU use for slow targets we currently used buffered
+writing, which appears to limit out at just above 150Mb/s per target, more than
+enough for the needs of the vector project today.
 
 ## Weird Quirks
 
@@ -65,3 +67,6 @@ limitation needs to be lifted we'll have to contribute a fix upstream, or adjust
 our rate limiting approach.
 
 Json generation is painfully slow. I'm very open to alternative approaches.
+
+The use of Arbitrary has been... interesting. You'll find that Ascii generates a
+lot of empty lines.

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -23,7 +23,7 @@ impl<'a> Arbitrary<'a> for Member {
     }
 
     fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (100, Some(6144)) // 100B to 6KiB
+        (0, Some(6144)) // 100B to 6KiB
     }
 }
 


### PR DESCRIPTION
This commit re-introduces buffered writing, using less CPU when we have slow
targets. Once we have a need for GB/s range writing we'll need to figure
something else out but for now this is good enough. I'm more interested in
addressing generated data quality.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>