### PR TITLE
Make generated data less blank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "file_gen"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arbitrary",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_gen"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/src/file.rs
+++ b/src/file.rs
@@ -199,6 +199,11 @@ impl Log {
             maximum_bytes_per_file as f64,
             &labels
         );
+        gauge!(
+            "bytes_per_second",
+            f64::from(self.bytes_per_second.get()),
+            &labels
+        );
 
         let mut fp = BufWriter::with_capacity(
             ONE_MEBIBYTE * 100,

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -2,6 +2,7 @@ use crate::payload::{Error, Serialize};
 use arbitrary::{self, Arbitrary, Unstructured};
 use std::io::Write;
 
+const SIZES: [usize; 8] = [64, 128, 256, 512, 1024, 2048, 4096, 8192];
 const CHARSET: &[u8] =
     b"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789().,/\\{}[];:'\"";
 #[allow(clippy::cast_possible_truncation)]
@@ -14,7 +15,9 @@ struct Member {
 
 impl<'a> Arbitrary<'a> for Member {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut bytes: Vec<u8> = u.arbitrary()?;
+        let choice: u8 = u.arbitrary()?;
+        let size = SIZES[(choice as usize) % SIZES.len()];
+        let mut bytes: Vec<u8> = vec![0; size];
         u.fill_buffer(&mut bytes)?;
         bytes
             .iter_mut()
@@ -23,7 +26,7 @@ impl<'a> Arbitrary<'a> for Member {
     }
 
     fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, Some(6144)) // 100B to 6KiB
+        (128, Some(8192))
     }
 }
 


### PR DESCRIPTION
This commit ensures that the data we generate from Ascii and Json has a definite
size to it, primarily by selecting from a fixed array of sizes. This is... a
little less arbitrary than I would have liked but it's better than a file full
of blank lines.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>