### PR TITLE
Crash when a worker crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "file_gen"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arbitrary",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_gen"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/src/file.rs
+++ b/src/file.rs
@@ -206,7 +206,7 @@ impl Log {
             bytes_per_second,
             fs::OpenOptions::new()
                 .create(true)
-                .truncate(false)
+                .truncate(true)
                 .write(true)
                 .open(&self.path)
                 .await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,11 @@ async fn run(targets: HashMap<String, LogTargetTemplate>) {
             .for_each(|log| workers.push(log.spin()));
     });
 
-    while workers.next().await.is_some() {}
+    loop {
+        if let Some(res) = workers.next().await {
+            res.unwrap();
+        }
+    }
 }
 
 fn get_config() -> Config {

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -2,7 +2,7 @@ use crate::payload::{Error, Serialize};
 use arbitrary::{self, Arbitrary, Unstructured};
 use std::io::Write;
 
-const SIZES: [usize; 8] = [64, 128, 256, 512, 1024, 2048, 4096, 8192];
+const SIZES: [usize; 8] = [16, 32, 64, 128, 256, 512, 1024, 2048];
 const CHARSET: &[u8] =
     b"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789().,/\\{}[];:'\"";
 #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
We have discovered situations where file_gen runs out of disk space and then
quietly stop. This happens when testing vector once vector falls behind.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>