### PR TITLE
Fix malformed block creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.3",
@@ -981,7 +981,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
  "crossbeam-utils 0.8.3",
  "lazy_static",

--- a/src/bin/file_gen.rs
+++ b/src/bin/file_gen.rs
@@ -35,7 +35,7 @@ async fn run(targets: HashMap<String, LogTargetTemplate>) {
 
                 let tgt_name = format!("{}[{}]", name.clone(), duplicate);
                 let tgt = template.strike(duplicate);
-                Log::new(rand::thread_rng(), tgt_name, tgt).unwrap()
+                Log::new(tgt_name, tgt).unwrap()
             })
             .for_each(|log| workers.push(log.spin()));
     });

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,57 @@
+use crate::payload::{self, Serialize};
+use metrics::gauge;
+use std::convert::TryInto;
+use std::num::NonZeroU32;
+
+#[derive(Debug)]
+pub enum Error {
+    Payload(payload::Error),
+    Empty,
+}
+
+impl From<payload::Error> for Error {
+    fn from(error: payload::Error) -> Self {
+        Error::Payload(error)
+    }
+}
+
+#[derive(Debug)]
+pub struct Block {
+    pub total_bytes: NonZeroU32,
+    pub lines: u64,
+    pub bytes: Vec<u8>,
+}
+
+#[inline]
+fn total_newlines(input: &[u8]) -> u64 {
+    bytecount::count(input, b'\n') as u64
+}
+
+#[allow(clippy::ptr_arg)]
+#[allow(clippy::cast_precision_loss)]
+pub fn construct_block_cache<S>(
+    serializer: &S,
+    block_chunks: &[usize],
+    labels: &Vec<(String, String)>,
+) -> Vec<Block>
+where
+    S: Serialize,
+{
+    let mut block_cache: Vec<Block> = Vec::with_capacity(block_chunks.len());
+    for block_size in block_chunks {
+        let mut block: Vec<u8> = Vec::with_capacity(*block_size);
+        serializer.to_bytes(*block_size, &mut block).unwrap();
+        block.shrink_to_fit();
+        assert!(!block.is_empty());
+        let total_bytes = NonZeroU32::new(block.len().try_into().unwrap()).unwrap();
+        let newlines = total_newlines(&block);
+        block_cache.push(Block {
+            total_bytes,
+            lines: newlines,
+            bytes: block,
+        });
+    }
+    assert!(!block_cache.is_empty());
+    gauge!("block_construction_complete", 1.0, labels);
+    block_cache
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,6 @@
 use crate::block::{self, construct_block_cache, Block};
 use crate::config::{LogTarget, Variant};
 use crate::payload;
-use arbitrary;
 use governor::state::direct::{self, InsufficientCapacity};
 use governor::{clock, state, Quota, RateLimiter};
 use metrics::{counter, gauge};
@@ -94,6 +93,11 @@ impl Log {
     /// # Errors
     ///
     /// Creation will fail if the target file cannot be opened for writing.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if variant is Static and the `static_path` is not
+    /// set.
     pub fn new(name: String, target: LogTarget) -> Result<Self, Error> {
         let mut rng = rand::thread_rng();
         let rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 
 use metrics::{register_counter, register_gauge, Unit};
 
-mod payload;
-//pub mod buffer;
+mod block;
 pub mod config;
 mod file;
+mod payload;
 
 pub use file::Log;
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -32,7 +32,7 @@ impl From<io::Error> for Error {
 }
 
 pub trait Serialize {
-    fn to_bytes<W>(&self, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W>(&self, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write;
 }

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -1,5 +1,6 @@
 use crate::payload::{Error, Serialize};
-use arbitrary::{self, Arbitrary, Unstructured};
+use arbitrary::{self, Unstructured};
+use rand::{thread_rng, RngCore};
 use std::io::Write;
 
 const SIZES: [usize; 8] = [16, 32, 64, 128, 256, 512, 1024, 2048];
@@ -13,7 +14,7 @@ struct Member {
     bytes: Vec<u8>,
 }
 
-impl<'a> Arbitrary<'a> for Member {
+impl<'a> arbitrary::Arbitrary<'a> for Member {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice: u8 = u.arbitrary()?;
         let size = SIZES[(choice as usize) % SIZES.len()];
@@ -30,18 +31,30 @@ impl<'a> Arbitrary<'a> for Member {
     }
 }
 
-#[derive(Arbitrary, Debug)]
-pub struct Ascii {
-    members: Vec<Member>,
-}
+#[derive(Debug, Default)]
+pub struct Ascii {}
 
 impl Serialize for Ascii {
-    fn to_bytes<W>(&self, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W>(&self, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
-        for member in &self.members {
-            writeln!(writer, "{}", std::str::from_utf8(&member.bytes).unwrap())?;
+        let mut rng = thread_rng();
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let mut unstructured = Unstructured::new(&entropy);
+
+        let mut bytes_remaining = max_bytes;
+        while let Ok(member) = unstructured.arbitrary::<Member>() {
+            let encoding = std::str::from_utf8(&member.bytes).unwrap();
+            let line_length = encoding.len() + 1; // add one for the newline
+            match bytes_remaining.checked_sub(line_length) {
+                Some(remainder) => {
+                    writeln!(writer, "{}", encoding)?;
+                    bytes_remaining = remainder
+                }
+                None => break,
+            }
         }
         Ok(())
     }

--- a/src/payload/ascii.rs
+++ b/src/payload/ascii.rs
@@ -51,7 +51,7 @@ impl Serialize for Ascii {
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
                     writeln!(writer, "{}", encoding)?;
-                    bytes_remaining = remainder
+                    bytes_remaining = remainder;
                 }
                 None => break,
             }

--- a/src/payload/foundationdb.rs
+++ b/src/payload/foundationdb.rs
@@ -133,7 +133,7 @@ impl Serialize for FoundationDb {
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
                     writeln!(writer, "{}", encoding)?;
-                    bytes_remaining = remainder
+                    bytes_remaining = remainder;
                 }
                 None => break,
             }

--- a/src/payload/json.rs
+++ b/src/payload/json.rs
@@ -1,5 +1,6 @@
 use crate::payload::{Error, Serialize};
 use arbitrary::{size_hint, Arbitrary, Unstructured};
+use rand::{thread_rng, RngCore};
 use std::io::Write;
 
 const SIZES: [usize; 13] = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048];
@@ -47,19 +48,30 @@ impl<'a> Arbitrary<'a> for Member {
     }
 }
 
-#[derive(Arbitrary, Debug)]
-pub struct Json {
-    members: Vec<Member>,
-}
+#[derive(Debug, Default)]
+pub struct Json {}
 
 impl Serialize for Json {
-    fn to_bytes<W>(&self, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W>(&self, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
-        for member in &self.members {
-            serde_json::to_writer(&mut *writer, member)?;
-            writeln!(writer)?;
+        let mut rng = thread_rng();
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let mut unstructured = Unstructured::new(&entropy);
+
+        let mut bytes_remaining = max_bytes;
+        while let Ok(member) = unstructured.arbitrary::<Member>() {
+            let encoding = serde_json::to_string(&member)?;
+            let line_length = encoding.len() + 1; // add one for the newline
+            match bytes_remaining.checked_sub(line_length) {
+                Some(remainder) => {
+                    writeln!(writer, "{}", encoding)?;
+                    bytes_remaining = remainder
+                }
+                None => break,
+            }
         }
         Ok(())
     }

--- a/src/payload/json.rs
+++ b/src/payload/json.rs
@@ -68,7 +68,7 @@ impl Serialize for Json {
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
                     writeln!(writer, "{}", encoding)?;
-                    bytes_remaining = remainder
+                    bytes_remaining = remainder;
                 }
                 None => break,
             }

--- a/src/payload/statik.rs
+++ b/src/payload/statik.rs
@@ -2,19 +2,19 @@ use crate::payload::{Error, Serialize};
 use std::io::{BufRead, Write};
 use std::path::Path;
 
+#[derive(Debug)]
 pub struct Static<'a> {
     path: &'a Path,
-    bytes_max: usize,
 }
 
 impl<'a> Static<'a> {
-    pub fn new(bytes_max: usize, path: &'a Path) -> Self {
-        Self { path, bytes_max }
+    pub fn new(path: &'a Path) -> Self {
+        Self { path }
     }
 }
 
 impl<'a> Serialize for Static<'a> {
-    fn to_bytes<W>(&self, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W>(&self, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
@@ -24,7 +24,7 @@ impl<'a> Serialize for Static<'a> {
         let file = std::fs::OpenOptions::new().read(true).open(self.path)?;
         let mut reader = std::io::BufReader::new(file);
 
-        let mut bytes_remaining = self.bytes_max;
+        let mut bytes_remaining = max_bytes;
         let mut line = String::new();
         while bytes_remaining > 0 {
             let len = reader.read_line(&mut line)?;


### PR DESCRIPTION
Previously it was possible for file_gen to crash when generating new blocks as a
result of those blocks outpacing the governor. To resolve this I've hidden the
Arbitrary definition behind a slightly reworked Serializer trait. The caller is
now responsible for setting up instances of Serializer and nothing more.

Startup is now slower, unfortunately, because the Serializer isn't Sync + Send
necessarily, but that couldn't be helped.

Resolves #45. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>