### PR TITLE
Add the ability to generate Datadog Log payloads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
 /// This variant controls what kind of line text is created by this program.
 #[derive(Debug, Deserialize, Copy, Clone)]
 pub enum Variant {
+    /// Generates Datadog Logs JSON messages
+    DatadogLog,
     /// Generates a limited subset of FoundationDB logs
     FoundationDb,
     /// Generates a static, user supplied data

--- a/src/file.rs
+++ b/src/file.rs
@@ -117,6 +117,9 @@ impl Log {
             Variant::Ascii => {
                 construct_block_cache(&payload::Ascii::default(), &block_chunks, &labels)
             }
+            Variant::DatadogLog => {
+                construct_block_cache(&payload::DatadogLog::default(), &block_chunks, &labels)
+            }
             Variant::Json => {
                 construct_block_cache(&payload::Json::default(), &block_chunks, &labels)
             }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,11 +1,14 @@
 use std::io::{self, Write};
 
 mod ascii;
+mod common;
+mod datadog_logs;
 mod foundationdb;
 mod json;
 mod statik;
 
 pub use ascii::Ascii;
+pub use datadog_logs::DatadogLog;
 pub use foundationdb::FoundationDb;
 pub use json::Json;
 pub use statik::Static;

--- a/src/payload/common.rs
+++ b/src/payload/common.rs
@@ -1,0 +1,45 @@
+use arbitrary::Unstructured;
+
+const SIZES: [usize; 8] = [16, 32, 64, 128, 256, 512, 1024, 2048];
+const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789().,";
+#[allow(clippy::cast_possible_truncation)]
+const CHARSET_LEN: u8 = CHARSET.len() as u8;
+
+#[derive(Debug)]
+pub struct AsciiStr {
+    bytes: Vec<u8>,
+}
+
+impl serde::Serialize for AsciiStr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl AsciiStr {
+    pub fn as_str(&self) -> &str {
+        // Safety: given that CHARSET is where we derive members from
+        // `self.bytes` is always valid UTF-8.
+        unsafe { std::str::from_utf8_unchecked(&self.bytes) }
+    }
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for AsciiStr {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let choice: u8 = u.arbitrary()?;
+        let size = SIZES[(choice as usize) % SIZES.len()];
+        let mut bytes: Vec<u8> = vec![0; size];
+        u.fill_buffer(&mut bytes)?;
+        bytes
+            .iter_mut()
+            .for_each(|item| *item = CHARSET[(*item % CHARSET_LEN) as usize]);
+        Ok(Self { bytes })
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (128, Some(8192))
+    }
+}

--- a/src/payload/datadog_logs.rs
+++ b/src/payload/datadog_logs.rs
@@ -1,12 +1,21 @@
-use crate::payload::{common::AsciiStr, Error, Serialize};
-use arbitrary::{self, Unstructured};
+use crate::payload::common::AsciiStr;
+use crate::payload::{Error, Serialize};
+use arbitrary::{Arbitrary, Unstructured};
 use rand::{thread_rng, RngCore};
 use std::io::Write;
 
-#[derive(Debug, Default)]
-pub struct Ascii {}
+#[derive(Arbitrary, Debug, serde::Serialize)]
+struct Member {
+    /// The message is a short ascii string, without newlines for now
+    pub message: AsciiStr,
+    /// The timestamp is a simple integer value since epoch, presumably
+    pub timestamp: u32,
+}
 
-impl Serialize for Ascii {
+#[derive(Debug, Default)]
+pub struct DatadogLog {}
+
+impl Serialize for DatadogLog {
     fn to_bytes<W>(&self, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
@@ -17,8 +26,8 @@ impl Serialize for Ascii {
         let mut unstructured = Unstructured::new(&entropy);
 
         let mut bytes_remaining = max_bytes;
-        while let Ok(member) = unstructured.arbitrary::<AsciiStr>() {
-            let encoding = member.as_str();
+        while let Ok(member) = unstructured.arbitrary::<Vec<Member>>() {
+            let encoding = serde_json::to_string(&member)?;
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {


### PR DESCRIPTION
It's now possible for this program to generate Datadog agent's log
payloads. This is in preparation for an HTTP generator in a similar manner to
file_gen, implying that this repo is increasingly misnamed and misdocumented.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>